### PR TITLE
fix-namespaced-rbac: 403s

### DIFF
--- a/helm/operator/templates/role.yaml
+++ b/helm/operator/templates/role.yaml
@@ -13,9 +13,9 @@ metadata:
   {{- end }}
 rules:
   - apiGroups:
-      - secrets.premiscale.com/v1alpha1
+      - secrets.premiscale.com
     resources:
-      - passsecrets
+      - '*'
     verbs:
       - list
       - get


### PR DESCRIPTION
Getting the following error in operator logs ~

```text
kopf._cogs.clients.errors.APIForbiddenError: ('passsecrets.secrets.premiscale.com is forbidden: User "system:serviceaccount:pass-operator-develop:pass-operator" cannot list resource "passsecrets" in API group "secrets.premiscale.com" in the namespace "pass-operator-develop"', {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'passsecrets.secrets.premiscale.com is forbidden: User "system:serviceaccount:pass-operator-develop:pass-operator" cannot list resource "passsecrets" in API group "secrets.premiscale.com" in the namespace "pass-operator-develop"', 'reason': 'Forbidden', 'details': {'group': 'secrets.premiscale.com', 'kind': 'passsecrets'}, 'code': 403})
```