### PR TITLE
Fix keyerror

### DIFF
--- a/src/passoperator/secret.py
+++ b/src/passoperator/secret.py
@@ -252,7 +252,7 @@ class PassSecret:
             PassSecret: the PassSecret object created from the body.
         """
         # Camelize the body to match the PassSecret object's fields, but keep the encryptedData field as-is.
-        camelized_body = camelize(dict(body))
+        camelized_body = dict(camelize(dict(body)))
         camelized_body['spec']['encryptedData'] = dict(body)['spec']['encryptedData']
 
         return from_dict(


### PR DESCRIPTION
```text
2024-05-15 21:27:41,632 | ERROR | kopf.objects | Handler 'create' failed with an exception. Will retry.
Traceback (most recent call last):
  File "/opt/pass-operator/.cache/pypoetry/virtualenvs/pass-operator-V_NVHGB_-py3.10/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 276, in execute_handler_once
    result = await invoke_handler(
  File "/opt/pass-operator/.cache/pypoetry/virtualenvs/pass-operator-V_NVHGB_-py3.10/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 371, in invoke_handler
    result = await invocation.invoke(
  File "/opt/pass-operator/.cache/pypoetry/virtualenvs/pass-operator-V_NVHGB_-py3.10/lib/python3.10/site-packages/kopf/_core/actions/invocation.py", line 139, in invoke
    await asyncio.shield(future)  # slightly expensive: creates tasks
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/pass-operator/src/passoperator/daemon.py", line 203, in create
    **passSecretObj.spec.managedSecret.to_client_dict()
  File "/opt/pass-operator/src/passoperator/secret.py", line 104, in to_client_dict
    d.pop('stringData')
KeyError: 'stringData'
2024-05-15 21:27:41,640 | DEBUG | kopf.objects | Patching with: {'metadata': {'annotations': {'kopf.zalando.org/create': '{"started":"2024-05-15T21:27:40.871937+00:00","delayed":"2024-05-15T21:28:41.639770+00:00","purpose":"create","retries":1,"success":false,"failure":false
,"message":"\'stringData\'"}'}}, 'status': {'kopf': {'progress': {'create': {'started': '2024-05-15T21:27:40.871937+00:00', 'stopped': None, 'delayed': '2024-05-15T21:28:41.639770+00:00', 'purpose': 'create', 'retries': 1, 'success': False, 'failure': False, 'message': "'str
ingData'", 'subrefs': None}}}}}
2024-05-15 21:27:41,657 | WARNING | kopf.objects | Patching failed with inconsistencies: (('remove', ('status', 'kopf'), {'progress': {'create': {'started': '2024-05-15T21:27:40.871937+00:00', 'stopped': None, 'delayed': '2024-05-15T21:28:41.639770+00:00', 'purpose': 'create
', 'retries': 1, 'success': False, 'failure': False, 'message': "'stringData'", 'subrefs': None}}}, None),)
```